### PR TITLE
update runtime to nodejs10.x

### DIFF
--- a/cloudformation/gov-cloud-import-commercial.json
+++ b/cloudformation/gov-cloud-import-commercial.json
@@ -89,7 +89,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/initStepFunction.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -107,7 +107,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/importImageStatus.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -125,7 +125,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/moveStatus.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -143,7 +143,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/cleanUp.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -161,7 +161,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/ec2Run.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -179,7 +179,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/makeVolume.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -197,7 +197,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/removeS3Image.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -215,7 +215,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/moveImage.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -233,7 +233,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/importImage.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -251,7 +251,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/makeVolumeStatus.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -269,7 +269,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/initS3Sync.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -287,7 +287,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/listGovBuckets.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -305,7 +305,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/listComBuckets.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -323,7 +323,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/appStatus.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -341,7 +341,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/snsSubscribe.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },
@@ -359,7 +359,7 @@
                   "S3Bucket": { "Fn::FindInMap" : [ "RegionMap", { "Ref" : "AWS::Region" }, "bucket"]},
                   "S3Key": "lambda/snsPublish.zip"
                 },
-                "Runtime": "nodejs8.10",
+                "Runtime": "nodejs10.x",
                 "Timeout": "120"
             }
         },


### PR DESCRIPTION
`nodejs8.10` runtime is no longer supported

```The runtime parameter of nodejs8.10 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (nodejs12.x) while creating or updating functions.```

I only updated to `nodejs10.x` to stay as close to the original runtime as possible and avoid issues.

