### PR TITLE
Issue #25 - specify that user needs to enter commercial region keys

### DIFF
--- a/index.html
+++ b/index.html
@@ -293,8 +293,8 @@
 		<div data-role="content" data-theme="a">
       <fieldset class="ui-grid-a">
         <div class="ui-block-a">
-          AWS Access Key: <input type="text" id="comAccess" value="">
-          AWS Secret Key: <input type="password" id="comSecret" value="">
+          Commercial Region AWS Access Key: <input type="text" id="comAccess" value="">
+          Commercial Region AWS Secret Key: <input type="password" id="comSecret" value="">
 					<label for="govRegion">AWS GovCloud (US) Region:</label>
 					<select name="govRegion" id="govRegion" data-iconpos="left">
 							<option>Select</option>


### PR DESCRIPTION
Specify that user needs to enter their commercial region access keys. It gets confusing with the govcloud region specified right below that. Changing the text to call out commercial region requirement. I wasted some time inputting my govcloud access keys, then finally figured it out. Hoping to save others some time.

Issue #, if available:
25
Description of changes:
Specifically state that the access keys needed are for the commercial region.

Screen shot of tested code:
<img width="769" alt="Screen Shot 2020-08-15 at 10 25 59 PM" src="https://user-images.githubusercontent.com/304930/90325357-a1001d00-df48-11ea-93f5-51f62553b7b3.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
